### PR TITLE
Improve handling of profiles

### DIFF
--- a/modules/lib-bash/activation-init.bash
+++ b/modules/lib-bash/activation-init.bash
@@ -4,7 +4,7 @@ function setupVars() {
   declare -r pmGcrootsDir="$stateHome/project-manager/gcroots"
 
   declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
-    declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user"
+  declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user"
 
   # If the user Nix profiles path exists, then place the PM profile there.
   # Otherwise, if the global Nix per-user state directory exists then use
@@ -21,7 +21,8 @@ function setupVars() {
     exit 1
   fi
 
-  declare -gr genProfilePath="$profilesDir/project-manager"
+  mkdir -p "$profilesDir/project-manager"
+  declare -gr genProfilePath="$profilesDir/project-manager/@PROJECT_NAME@"
   declare -gr newGenPath="@GENERATION_DIR@"
   declare -gr newGenGcPath="$pmGcrootsDir/current-project"
 

--- a/modules/project-environment.nix
+++ b/modules/project-environment.nix
@@ -530,7 +530,8 @@ in {
           ln -s $out/activate $out/bin/project-manager-generation
 
           substituteInPlace $out/activate \
-            --subst-var-by GENERATION_DIR $out
+            --subst-var-by GENERATION_DIR $out \
+            --subst-var-by PROJECT_NAME "${config.project.name}"
 
           ln -s ${config.project-files} $out/project-files
 

--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -108,6 +108,35 @@ function setConfigFile() {
   fi
 }
 
+# Sets some useful Project Manager related paths as global read-only variables.
+function setProjectManagerPathVariables() {
+  # If called twice then just exit early.
+  if [[ -v PM_DATA_HOME ]]; then
+    return
+  fi
+
+  declare -r globalNixStateDir="${NIX_STATE_DIR:-/nix/var/nix}"
+  declare -r globalProfilesDir="$globalNixStateDir/profiles/per-user/$USER"
+
+  declare -r stateHome="${XDG_STATE_HOME:-$HOME/.local/state}"
+  declare -r userNixStateDir="$stateHome/nix"
+
+  declare -gr PM_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/project-manager"
+  declare -gr PM_STATE_DIR="$stateHome/project-manager"
+
+  if [[ -d $userNixStateDir/profiles ]]; then
+    declare -gr PM_PROFILE_DIR="$userNixStateDir/profiles/project-manager"
+  elif [[ -d $globalProfilesDir ]]; then
+    declare -gr PM_PROFILE_DIR="$globalProfilesDir/project-manager"
+  else
+    _iError 'Could not find suitable profile directory, tried %s and %s' \
+      "$PM_STATE_DIR/profiles" "$globalProfilesDir" >&2
+    exit 1
+  fi
+
+  PM_PROJECT_NAME="$(nix eval --raw .#projectConfigurations.aarch64-darwin.config.project.name)"
+}
+
 function setFlakeAttribute() {
   local flake="."
   local name
@@ -433,6 +462,8 @@ function doSwitch() {
 }
 
 function doListGens() {
+  setProjectManagerPathVariables
+
   # Whether to colorize the generations output.
   local color="never"
   if [[ ! -v NO_COLOR && -t 1 ]]; then
@@ -441,21 +472,22 @@ function doListGens() {
 
   pushd "$PM_PROFILE_DIR" > /dev/null || exit
   # shellcheck disable=2012
-  ls --color=$color -gG --time-style=long-iso --sort time project-manager-*-link \
+  ls --color=$color -gG --time-style=long-iso --sort time "${PM_PROJECT_NAME}-*-link" \
     | cut -d' ' -f 4- \
-    | sed -E 's/project-manager-([[:digit:]]*)-link/: id \1/'
+    | sed -E "s/${PM_PROJECT_NAME}-([[:digit:]]*)-link/: id \\1/"
   popd > /dev/null || exit
 }
 
 # Removes linked generations. Takes as arguments identifiers of
 # generations to remove.
 function doRmGenerations() {
+  setProjectManagerPathVariables
   setVerboseAndDryRun
 
   pushd "$PM_PROFILE_DIR" > /dev/null || exit
 
   for generationId in "$@"; do
-    local linkName="project-manager-$generationId-link"
+    local linkName="${PM_PROJECT_NAME}-$generationId-link"
 
     if [[ ! -e $linkName ]]; then
       _i 'No generation with ID %s' "$generationId" >&2
@@ -471,9 +503,11 @@ function doRmGenerations() {
 }
 
 function doExpireGenerations() {
+  setProjectManagerPathVariables
+
   local generations
   generations="$(
-    find "$PM_PROFILE_DIR" -name 'project-manager-*-link' -not -newermt "$1" \
+    find "$PM_PROFILE_DIR" -name '${PM_PROJECT_NAME}-*-link' -not -newermt "$1" \
       | sed 's/^.*-\([0-9]*\)-link$/\1/'
   )"
 
@@ -624,10 +658,6 @@ function doUninstall() {
 
       if [[ -e $PM_PROFILE_DIR ]]; then
         $DRY_RUN_CMD rm $VERBOSE_ARG "$PM_PROFILE_DIR/project-manager"*
-      fi
-
-      if [[ -e $PM_GCROOT_LEGACY_PATH ]]; then
-        $DRY_RUN_CMD rm $VERBOSE_ARG "$PM_GCROOT_LEGACY_PATH"
       fi
       ;;
     *)


### PR DESCRIPTION
Previously all project-manager projects shared a single profile, which was just
wrong and led to a bunch of confusing behaviors.

This improves the situation by having a profile per project-name. This still
isn’t quite right, as we should have one per working tree, but it’s a significant
improvement.

Down the road, I’m not sure how useful profiles are, other than the current
one (so we can reference it when it becomes the previous one). This is because
everything here should be managed via some VCS, so a previous generation
generally corresponds to a previous state of the repository, so why duplicate
that?

**NB**: This is incompatible with previous version of Project Manager.