### PR TITLE
Configure ShellCheck without generating a file

### DIFF
--- a/.config/project/default.nix
+++ b/.config/project/default.nix
@@ -34,9 +34,18 @@
   ## formatting
   editorconfig.enable = true;
   programs = {
-    shellcheck.enable = true;
-    shellcheck.settings.minimum-persistence = "repository";
-
+    shellcheck = {
+      enable = true;
+      ## TODO: Move this up to flaky.
+      directives.disable = [
+        # Unicode quotes are good, and ShellCheck gets this wrong a lot.
+        "SC1111"
+        "SC1112"
+        # `shfmt` likes to replace `"\$foo"` with '$foo', which then triggers this
+        # complaint, so let shfmt do what it wants.
+        "SC2016"
+      ];
+    };
     treefmt = {
       enable = true;
       ## Shell linter

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 /.editorconfig linguist-generated
 /.gitattributes linguist-generated
 /.github/settings.yml linguist-generated
-/.shellcheckrc linguist-generated
 /.github/workflows/flakehub-publish.yml linguist-generated
 /.github/workflows/flakestry-publish.yml linguist-generated
 /garnix.yaml linguist-generated

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,8 +1,0 @@
-## -*- mode: sh -*-
-
-# Unicode quotes are good, and ShellCheck gets this wrong a lot.
-disable=SC1111,SC1112
-
-# `shfmt` likes to replace `"\$foo"` with '$foo', which then triggers this
-# complaint, so let shfmt do what it wants.
-disable=SC2016

--- a/modules/programs/shellcheck.nix
+++ b/modules/programs/shellcheck.nix
@@ -16,6 +16,62 @@
       commit-by-default = config.project.commit-by-default;
     })
     .fileContents;
+
+  directiveModule = lib.types.submodule {
+    options = {
+      disable = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = lib.mdDoc ''
+          Prevent ShellCheck from processing one or more warnings. A
+          hyphen-separated range of errors can also be specified, handy when
+          disabling things for the entire file. An alias `all` is available
+          instead of specifying 0-9999 to disable all checks.
+        '';
+      };
+
+      enable = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = lib.mdDoc ''
+          Enables an optional check (since 0.7.0). To see a list of optional
+          checks with examples, run shellcheck --list-optional. See
+          https://github.com/koalaman/shellcheck/wiki/optional for more
+          information.
+        '';
+      };
+
+      external-sources = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = lib.mdDoc ''
+          Set whether or not to follow arbitrary file paths in source statements.
+        '';
+      };
+
+      source-path = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = lib.mdDoc ''
+          Give ShellCheck a path in which to search for sourced files. The special
+          value `source-path=SCRIPTDIR` will search in the current script's
+          directory, and it can be used as a relative path like
+          `source-path=SCRIPTDIR/../lib`. To support the common pattern of
+          `. "$CONFIGDIR/mylib.sh"`, ShellCheck strips one leading, dynamic
+          section before trying to locate the rest.
+        '';
+      };
+
+      shell = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = lib.mdDoc ''
+          Specify the shell for a script (similar to the shebang, if you for any
+          reason don't want to add one).
+        '';
+      };
+    };
+  };
 in {
   options.programs.shellcheck = {
     enable = lib.mkEnableOption (lib.mdDoc "ShellCheck");
@@ -24,43 +80,138 @@ in {
       default = ["shellcheck"];
     };
 
+    wrapProgram = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      apply = p:
+        if p == null
+        then config.project.wrapPrograms
+        else p;
+
+      description = lib.mdDoc ''
+        Whether to wrap the executable to work without a config file in the
+        worktree or to produce the config file. If null, this falls back to
+        {var}`config.project.wrapPrograms`.
+      '';
+    };
+
+    ## TODO: This option is deprecated. Remove once flaky has been updated (and
+    ##       remove `fileContents` with it).
     settings = lib.mkOption {
       type = fileContents "programs.shellcheck" "" projectDirectory "settings";
       description = lib.mdDoc ''
         The .shellcheckrc file. The `target` is ignored.
       '';
     };
+
+    directives = lib.mkOption {
+      type = directiveModule;
+      default = {};
+      description = lib.mdDoc ''
+        Shellcheck directives allow you to control how shellcheck works.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (let
-    wrapped = cfg.package.overrideAttrs (old: {
-      ## TODO: Extract out the bit that manages all the
-      ##       (sym)linking/copying, so we can use it consistently.
-      postBuild = ''
-        wrapProgram shellcheck \
-          --run "trap \"rm ${config.project.file.".shellcheckrc".target}\"" EXIT
-          --run "cp ${config.project.file.".shellcheckrc".source}" ${config.project.file.".shellcheckrc".target}"
-      '';
-    });
+    disabled = builtins.concatStringsSep "," cfg.directives.disable;
+    enabled = builtins.concatStringsSep "," cfg.directives.enable;
+    source-paths = builtins.concatStringsSep "," cfg.directives.source-path;
+
+    wrapped =
+      if cfg.wrapProgram
+      then let
+        flags = lib.concatStringsSep " " (builtins.concatLists [
+          (
+            if cfg.directives.disable == []
+            then []
+            else ["--exclude=${disabled}"]
+          )
+          (
+            if cfg.directives.enable == []
+            then []
+            else ["--enable=${enabled}"]
+          )
+          (
+            if cfg.directives.external-sources == null
+            then []
+            else ["--external-sources"]
+          )
+          (
+            if cfg.directives.source-path == []
+            then []
+            else ["--source-path=${source-paths}"]
+          )
+          (
+            if cfg.directives.shell == null
+            then []
+            else ["--shell=${cfg.directives.shell}"]
+          )
+        ]);
+      in
+        cfg.package.overrideAttrs (old: {
+          # NB: This seems to get reset by `overrideAttrs`.
+          inherit (old) meta;
+
+          nativeBuildInputs = old.nativeBuildInputs ++ [pkgs.makeWrapper];
+
+          ## NB: The shellcheck derivation doesn’t call any pre/post hooks.
+          installPhase =
+            old.installPhase
+            + ''
+              wrapProgram "$bin/bin/shellcheck" --add-flags "${flags}"
+            '';
+        })
+      else cfg.package;
   in {
     project = {
       checks.shellcheck = bash-strict-mode.lib.checkedDrv pkgs (pkgs.runCommand "shellcheck" {
           nativeBuildInputs = [wrapped];
-          src = config.project.cleanRepositoryPersisted self;
+          src = config.project.cleanRepositoryPersistedExcept [".shellcheckrc"] self;
         }
         ''
-          ${wrapped}/bin/shellcheck "$src/project-manager/project-manager"
+          shellcheck "$src/project-manager/project-manager"
           mkdir -p "$out"
         '');
 
-      file.".shellcheckrc" =
-        cfg.settings
-        // {
-          target = ".shellcheckrc";
-          # minimum-persistence = "store";
-        };
+      file.".shellcheckrc" = lib.mkIf (!cfg.wrapProgram) (
+        if cfg.directives == {}
+        then cfg.settings // {target = ".shellcheckrc";}
+        else {
+          text = lib.concatLines (lib.concatLists [
+            ["# This file was generated by Project Manager."]
+            (
+              if cfg.directives.disable == []
+              then []
+              else ["disable=${disabled}"]
+            )
+            (
+              if cfg.directives.enable == []
+              then []
+              else ["enable=${enabled}"]
+            )
+            (
+              if cfg.directives.external-sources == null
+              then []
+              else ["external-sources=${cfg.directives.external-sources}"]
+            )
+            (
+              if cfg.directives.source-path == []
+              then []
+              else ["source-path=${source-paths}"]
+            )
+            (
+              if cfg.directives.shell == null
+              then []
+              else ["shell=${cfg.directives.shell}"]
+            )
+          ]);
+        }
+      );
 
-      packages = [cfg.package]; # [wrapped];
+      packages = [wrapped];
     };
+
+    programs.treefmt.programs.shellcheck.package = wrapped;
   });
 }

--- a/modules/programs/treefmt.nix
+++ b/modules/programs/treefmt.nix
@@ -11,9 +11,7 @@ in {
   options.programs.treefmt = {
     enable = lib.mkEnableOption (lib.mdDoc "treefmt");
 
-    package = lib.mkPackageOptionMD pkgs "treefmt" {
-      default = ["treefmt"];
-    };
+    package = lib.mkPackageOptionMD pkgs "treefmt" {};
 
     projectRootFile = lib.mkOption {
       type = lib.types.str;
@@ -24,7 +22,7 @@ in {
     };
 
     programs = lib.mkOption {
-      type = lib.types.attrs;
+      type = lib.types.attrsOf lib.types.attrs;
       default = {};
       description = lib.mdDoc ''
         Configuration for treefmt formatters. See
@@ -33,7 +31,7 @@ in {
     };
 
     settings = lib.mkOption {
-      type = lib.types.attrs;
+      type = lib.types.attrsOf lib.types.attrs;
       default = {};
       description = lib.mdDoc ''
         Settings for treefmt. See

--- a/modules/project-environment.nix
+++ b/modules/project-environment.nix
@@ -83,6 +83,20 @@ in {
       '';
     };
 
+    wrapPrograms = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      apply = p:
+        if p == null
+        then !cfg.commit-by-default
+        else p;
+      description = lib.mdDoc ''
+        Whether to default to wrapping programs instead of writing configuration
+        files. If null, it falls back to the opposite of
+        {var}`project.commit-by-default`.
+      '';
+    };
+
     shellAliases = mkOption {
       type = with types; attrsOf str;
       default = {};


### PR DESCRIPTION
This is the model of a new feature in Project Manager – configuration without
files. It instead wraps the program to set up the environment or pass flags to
replicate the behavior of the config file.

This is controlled by three options:
- `wrapProgram` at the module level, which falls back to
- `project.wrapPrograms`, which falls back to (the opposite of)
- `project.commit-by-default`.

The last of those is because `commit-by-default` is generally a proxy for
non-Nix-using contributors, and those same contributors would also have trouble
with this feature.

This also gives more structure to the ShellCheck module, necessitated by having
to build either a config file or flags from it.