### PR TITLE
Add support for Nixpkgs 23.11

### DIFF
--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -54,7 +54,7 @@ A fresh install of Project Manager will generate a minimal `$PROJECT_ROOT/.confi
   # You can update Project Manager without changing this value. See
   # the Project Manager release notes for a list of state version
   # changes in each release.
-  project.stateVersion = "23.05";
+  project.stateVersion = 0;
 
   # Let Project Manager install and manage itself.
   programs.project-manager.enable = true;
@@ -89,7 +89,7 @@ To satisfy the above setup we should elaborate the `project.nix` file as follows
   # You can update Project Manager without changing this value. See
   # the Project Manager release notes for a list of state version
   # changes in each release.
-  project.stateVersion = "23.05";
+  project.stateVersion = 0;
 
   # Let Project Manager install and manage itself.
   programs.project-manager.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -5,9 +5,11 @@
         "flake-utils": [
           "flake-utils"
         ],
-        "flaky": "flaky",
+        "flaky": [
+          "flaky"
+        ],
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-23_11"
         ],
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
@@ -26,22 +28,6 @@
       }
     },
     "flake-schemas": {
-      "locked": {
-        "lastModified": 1693615451,
-        "narHash": "sha256-rrZipq8J+g+LFWMC0+M0R8+NnZoDdrLHDahcvxh8mgA=",
-        "owner": "DeterminateSystems",
-        "repo": "flake-schemas",
-        "rev": "cfd7826aabef39c337eb79053d0253f446c1c817",
-        "type": "github"
-      },
-      "original": {
-        "owner": "DeterminateSystems",
-        "ref": "support-nixos-modules",
-        "repo": "flake-schemas",
-        "type": "github"
-      }
-    },
-    "flake-schemas_2": {
       "locked": {
         "lastModified": 1697467827,
         "narHash": "sha256-j8SR19V1SRysyJwpOBF4TLuAvAjF5t+gMiboN4gYQDU=",
@@ -80,47 +66,20 @@
           "bash-strict-mode"
         ],
         "flake-utils": [
-          "bash-strict-mode",
           "flake-utils"
         ],
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
-        "project-manager": "project-manager"
-      },
-      "locked": {
-        "lastModified": 1697832912,
-        "narHash": "sha256-6N7QwbDWlH5oITdPXx1kdcITHQYALRIT1Cf9faDMJz4=",
-        "owner": "sellout",
-        "repo": "flaky",
-        "rev": "33066d3e060b51c194d838be990da97aff591536",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sellout",
-        "repo": "flaky",
-        "type": "github"
-      }
-    },
-    "flaky_2": {
-      "inputs": {
-        "bash-strict-mode": [
-          "bash-strict-mode"
-        ],
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "home-manager": "home-manager_2",
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-23_11"
         ],
         "project-manager": []
       },
       "locked": {
-        "lastModified": 1700350288,
-        "narHash": "sha256-z82u9n0tFiadazrKzrpErKx5wr3CI6fGLnI8VmgXCOk=",
+        "lastModified": 1701037822,
+        "narHash": "sha256-spp2L7onZ6Jnfks0MIiSeGYqeKFhs+TeqNC8QsrrPx0=",
         "owner": "sellout",
         "repo": "flaky",
-        "rev": "330146352875872e288f227c3c5af080da8837ca",
+        "rev": "953775ae60711820b2cc29869dfb3ef1ba8add52",
         "type": "github"
       },
       "original": {
@@ -132,81 +91,58 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "bash-strict-mode",
           "flaky",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1695108154,
-        "narHash": "sha256-gSg7UTVtls2yO9lKtP0yb66XBHT1Fx5qZSZbGMpSn2c=",
+        "lastModified": 1700814205,
+        "narHash": "sha256-lWqDPKHRbQfi+zNIivf031BUeyciVOtwCwTjyrhDB5g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "07682fff75d41f18327a871088d20af2710d4744",
+        "rev": "aeb2232d7a32530d3448318790534d196bf9427a",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
-          "flaky",
-          "nixpkgs"
-        ]
-      },
+    "nixpkgs-23_05": {
       "locked": {
-        "lastModified": 1699748081,
-        "narHash": "sha256-MOmMapBydd7MTjhX4eeQZzKlCABWw8W6iSHSG4OeFKE=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "04bac349d585c9df38d78e0285b780a140dc74a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-23.05",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1697828342,
-        "narHash": "sha256-DSaN5aa+Kyo84GoQL1dIg0H9AMLl8yU4q+uN2AjEi4s=",
+        "lastModified": 1701027176,
+        "narHash": "sha256-tNYEc6QClrExMdArIL9krYSPo/34U43DHwuBbgwfcoA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96f7c64907ccdb53e36b3c02b5165dfd491ec0db",
+        "rev": "835eab9a7bcaf4365fc96f5d1a756784aea0f5d1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23_11": {
+      "locked": {
+        "lastModified": 1701034356,
+        "narHash": "sha256-XuuC3BGQzUszyFQHQwSOgIJu0bmGFdPBFHsdvM0sn50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cdc719613f4cefb1572ef2d195581a5a44749f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1700856099,
         "narHash": "sha256-RnEA7iJ36Ay9jI0WwP+/y4zjEhmeN6Cjs9VOFBH7eVQ=",
@@ -222,66 +158,16 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1700905716,
-        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "project-manager": {
-      "inputs": {
-        "bash-strict-mode": [
-          "bash-strict-mode",
-          "flaky",
-          "bash-strict-mode"
-        ],
-        "flake-schemas": "flake-schemas",
-        "flake-utils": [
-          "bash-strict-mode",
-          "flaky",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "bash-strict-mode",
-          "flaky",
-          "nixpkgs"
-        ],
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1697773416,
-        "narHash": "sha256-uiRS7byPw0PSRno+Kzvsfvggx8pVCvQtMcocRDTS6ZU=",
-        "owner": "sellout",
-        "repo": "project-manager",
-        "rev": "36d951c1524bc629efa191cfe2e574b92d527843",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sellout",
-        "repo": "project-manager",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "bash-strict-mode": "bash-strict-mode",
-        "flake-schemas": "flake-schemas_2",
+        "flake-schemas": "flake-schemas",
         "flake-utils": "flake-utils",
-        "flaky": "flaky_2",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "treefmt-nix": "treefmt-nix_2"
+        "flaky": "flaky",
+        "nixpkgs-23_05": "nixpkgs-23_05",
+        "nixpkgs-23_11": "nixpkgs-23_11",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "shellcheck-nix-attributes": {
@@ -318,30 +204,7 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "bash-strict-mode",
-          "flaky",
-          "project-manager",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1695822946,
-        "narHash": "sha256-IQU3fYo0H+oGlqX5YrgZU3VRhbt2Oqe6KmslQKUO4II=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "720bd006d855b08e60664e4683ccddb7a9ff614a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-23_11"
         ]
       },
       "locked": {

--- a/modules/misc/version.nix
+++ b/modules/misc/version.nix
@@ -4,28 +4,25 @@
   ...
 }:
 with lib; let
-  releaseInfo = {
-    release = "23.05";
-    isReleaseBranch = true;
-  };
+  releaseInfo = import ../../release.nix;
 in {
   options = {
     project.stateVersion = mkOption {
-      type = types.enum [
-        "23.05"
-        "23.11"
-      ];
+      type = types.ints.between 0 releaseInfo.version.major;
       description = lib.mdDoc ''
-        It is occasionally necessary for Project Manager to change
-        configuration defaults in a way that is incompatible with
-        stateful data. This could, for example, include switching the
-        default data format or location of a file.
+        It is occasionally necessary for Project Manager to change configuration
+        defaults in a way that is incompatible with stateful data. This could,
+        for example, include switching the default data format or location of a
+        file.
 
-        The *state version* indicates which default
-        settings are in effect and will therefore help avoid breaking
-        program configurations. Switching to a higher state version
-        typically requires performing some manual steps, such as data
-        conversion or moving files.
+        The *state version* indicates which default settings are in effect and
+        will therefore help avoid breaking program configurations. Switching to
+        a higher state version typically requires performing some manual steps,
+        such as data conversion or moving files.
+
+        The state version corresponds to the major version component of the
+        Project Manager release where those defaults were specified. The value
+        can be set to any Project Manager release up to and including this one.
       '';
     };
 
@@ -39,7 +36,7 @@ in {
           suffix =
             optionalString (revision != null) "+${substring 0 8 revision}";
         in "${release}${suffix}";
-        example = "23.05+213a0629";
+        example = "0.3.0+213a0629";
         description = "The full Project Manager version.";
       };
 
@@ -48,7 +45,7 @@ in {
         readOnly = true;
         type = types.str;
         default = releaseInfo.release;
-        example = "23.05";
+        example = "0.3.0";
         description = "The Project Manager release.";
       };
 

--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -200,7 +200,7 @@ function doInit() {
   # You should not change this value, even if you update Project Manager. If you do
   # want to update the value, then make sure to first check the Project Manager
   # release notes.
-  project.stateVersion = "23.05"; # Please read the comment before changing.
+  project.stateVersion = 0; # Please read the comment before changing.
 
   # The project.packages option allows you to install Nix packages into your
   # environment.
@@ -609,7 +609,7 @@ function doUninstall() {
       PROJECT_MANAGER_CONFIG="$(mktemp --tmpdir project-manager.XXXXXXXXXX)"
       echo "{ lib, ... }: {" > "$PROJECT_MANAGER_CONFIG"
       echo "  project.file = lib.mkForce {};" >> "$PROJECT_MANAGER_CONFIG"
-      echo '  project.stateVersion = "18.09";' >> "$PROJECT_MANAGER_CONFIG"
+      echo '  project.stateVersion = 0;' >> "$PROJECT_MANAGER_CONFIG"
       echo "  manual.manpages.enable = false;" >> "$PROJECT_MANAGER_CONFIG"
       echo "}" >> "$PROJECT_MANAGER_CONFIG"
       doSwitch

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,14 @@
-{
-  release = "23.05";
+let
+  ## This follows Semantic Versioning 2.0.0 (https://semver.org/)
+  version = {
+    major = 0;
+    minor = 3;
+    patch = 0;
+  };
+in {
+  inherit version;
+  release = (
+    with version; "${toString major}.${toString minor}.${toString patch}"
+  );
   isReleaseBranch = true;
 }


### PR DESCRIPTION
This does a few other things as well:
- supports multiple Nixpkgs versions on the same branch (currently 23.05, 23.11, and unstable);
- switches `project.stateVersion` to match Project Manager major versions;
- modifies `project.enableNixpkgsReleaseCheck` to work between PM version & Nixpkgs version; and
- builds PM against 23.11.