### PR TITLE
Move published derivations under `packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ For this to do anything, you need to add a `projectConfigurations.${system}` out
 
 Once you define your `projectConfigurations`, there are a number of helpful attributes to take advantage of
 
-#### `activationPackage`
+#### `packages`
 
-Rarely used directly, this is the derivation behind `project-manager build` and `switch`. It’s what sets up your generated environment.
+- `packages.activation` – rarely used directly, this is the derivation behind `project-manager switch`. It’s what sets up your generated environment.
+- `packages.path` contains all of the packages referenced by the project configuration, it is used in devShells, etc. to make sure the right versions of the right commands are available. You might use it directly to add the packages to another derivation
+- `packages.sessionVariables` sets up the shell environment variables referenced by the project configuration.
 
 #### `checks`
 

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         "shellcheck-nix-attributes": "shellcheck-nix-attributes"
       },
       "locked": {
-        "lastModified": 1700257951,
-        "narHash": "sha256-/i3a6/oyphxK8ucGoWuw1Z1sICD1FXK4Rg8MUpubTHA=",
+        "lastModified": 1701068959,
+        "narHash": "sha256-9EkOn4rYXiIosLG8rjl/8uN1+OJ7QvbXSf4c4vkw1nc=",
         "owner": "sellout",
         "repo": "bash-strict-mode",
-        "rev": "4ac38b83873b5d6974722ed1dc9c8f64145ef24f",
+        "rev": "6290c8aa90350a1109ccd80e4b53061afb1aadf1",
         "type": "github"
       },
       "original": {
@@ -91,11 +91,11 @@
         "project-manager": []
       },
       "locked": {
-        "lastModified": 1701059260,
-        "narHash": "sha256-5mMvxdWZzE2gUJvbm1RYRrp1cOs1XJHiwnc5aBWu2Sg=",
+        "lastModified": 1701144318,
+        "narHash": "sha256-4ST2GMvgOsbGu9d/p4V+Sn/ovqbejGdf/a2NWrAO3is=",
         "owner": "sellout",
         "repo": "flaky",
-        "rev": "2d16a8c0d0405030c2af43cdb888680a040a4a9e",
+        "rev": "df5be5d9ee4a91cae6657191321ce729a194cf86",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
     },
     "nixpkgs-23_05": {
       "locked": {
-        "lastModified": 1701053011,
-        "narHash": "sha256-8QQ7rFbKFqgKgLoaXVJRh7Ik5LtI3pyBBCfOnNOGkF0=",
+        "lastModified": 1701140563,
+        "narHash": "sha256-wtNoJq2O46x9JJLkYx2p+I5c/bnFmZuN8PoTpahPCQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b528f99f73c4fad127118a8c1126b5e003b01a9",
+        "rev": "922913d8f51616ebeaeace98daf1cc88d21bb5ff",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
     },
     "nixpkgs-23_11": {
       "locked": {
-        "lastModified": 1701058557,
-        "narHash": "sha256-fux7HlrnoNs93MN0kET4AfiYwg/expoasndRCFeDRyk=",
+        "lastModified": 1701140410,
+        "narHash": "sha256-7N6GHwRhZJMnZKSX2LnInQ0mcHWuW1ElkdroQJ+91OQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "070b5cf9f70bc7ef2dfd739a1f7d6c563fe64bd1",
+        "rev": "3fb4ba1c4fb184679f0da105e8dd0ef6b4b07591",
         "type": "github"
       },
       "original": {
@@ -235,11 +235,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1700856099,
-        "narHash": "sha256-RnEA7iJ36Ay9jI0WwP+/y4zjEhmeN6Cjs9VOFBH7eVQ=",
+        "lastModified": 1701040486,
+        "narHash": "sha256-vawYwoHA5CwvjfqaT3A5CT9V36Eq43gxdwpux32Qkjw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bd59c54ef06bc34eca01e37d689f5e46b3fe2f1",
+        "rev": "45827faa2132b8eade424f6bdd48d8828754341a",
         "type": "github"
       },
       "original": {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -46,7 +46,7 @@ in {
 
   inherit
     (module.config.project)
-    activationPackage
+    packages
     checks
     devShells
     formatter

--- a/modules/project-environment.nix
+++ b/modules/project-environment.nix
@@ -425,10 +425,10 @@ in {
         lib.listToAttrs
         (map (name: lib.nameValuePair name []) unsupportedVersions)
         // {
-          "22.11" = ["0.3"];
-          "23.05" = ["0.1" "0.2" "0.3"];
-          "23.11" = ["0.3"];
-          "24.05" = ["0.3"];
+          "22.11" = ["0.3" "0.4"];
+          "23.05" = ["0.1" "0.2" "0.3" "0.4"];
+          "23.11" = ["0.3" "0.4"];
+          "24.05" = ["0.3" "0.4"];
         };
       pmRelease = config.project.version.release;
       nixpkgsRelease = lib.trivial.release;

--- a/modules/project-environment.nix
+++ b/modules/project-environment.nix
@@ -194,15 +194,6 @@ in {
       '';
     };
 
-    packages = mkOption {
-      type = types.listOf types.package;
-      default = [];
-      description = lib.mdDoc ''
-        The set of packages to appear in the project environment. This is now
-        deprecated.
-      '';
-    };
-
     devPackages = mkOption {
       type = types.listOf types.package;
       default = [];
@@ -220,11 +211,6 @@ in {
         {var}`project.devPackages` that should be installed into
         the user environment.
       '';
-    };
-
-    path = mkOption {
-      internal = true;
-      description = "The derivation installing the project packages.";
     };
 
     emptyActivationPath = mkOption {
@@ -284,21 +270,24 @@ in {
       '';
     };
 
-    activationPackage = mkOption {
+    packages = mkOption {
       internal = true;
-      type = types.package;
+      type = types.attrsOf types.package;
+      default = {};
       description = lib.mdDoc ''
-        The package containing the complete activation script.
+        Packages provided by the project configuration. These generally don’t
+        need to be explicitly referenced, as they’re part of the usual
+        functioning of Project Manager.
       '';
     };
 
     checks = mkOption {
       internal = true;
-      type = types.attrs;
+      type = types.attrsOf types.package;
       default = {};
       description = lib.mdDoc ''
-        A function that accepts the current flake (`self`) and returns attrset
-        of checks to be applied for the current system.
+        Checks provided by the project configuration. These can be included in
+        your flake’s checks.
       '';
     };
 
@@ -484,7 +473,7 @@ in {
     # programs.fish.shellAliases = cfg.shellAliases;
 
     # Provide a file holding all session variables.
-    project.sessionVariablesPackage = pkgs.writeTextFile {
+    project.packages.sessionVariables = pkgs.writeTextFile {
       name = "pm-session-vars.sh";
       destination = "/etc/profile.d/pm-session-vars.sh";
       text =
@@ -501,11 +490,9 @@ in {
         + cfg.sessionVariablesExtra;
     };
 
-    project.devPackages =
-      cfg.packages
-      ++ [
-        config.project.sessionVariablesPackage
-      ];
+    project.devPackages = [
+      config.project.packages.sessionVariables
+    ];
 
     # A dummy entry acting as a boundary between the activation
     # script's "check" and the "write" phases.
@@ -548,7 +535,7 @@ in {
         LIST_CMD="nix profile list --profile ${profileDir}"
         REMOVE_CMD_SYNTAX='nix profile remove --profile ${profileDir} {number | store path}'
 
-        if ! $INSTALL_CMD_ACTUAL ${cfg.path} ; then
+        if ! $INSTALL_CMD_ACTUAL ${cfg.packages.path} ; then
           echo
           _iError $'Oops, Nix failed to install your new Project Manager profile!\n\nPerhaps there is a conflict with a package that was installed using\n"%s"? Try running\n\n    %s\n\nand if there is a conflicting package you can remove it with\n\n    %s\n\nThen try activating your Project Manager configuration again.' "$INSTALL_CMD" "$LIST_CMD" "$REMOVE_CMD_SYNTAX"
           exit 1
@@ -580,7 +567,7 @@ in {
       source ${../lib/bash/project-manager.bash}
     '';
 
-    project.activationPackage = let
+    project.packages.activation = let
       mkCmd = res: ''
         _iNote "Activating %s" "${res.name}"
         ${res.data}
@@ -663,7 +650,7 @@ in {
           ${cfg.extraBuilderCommands}
         '');
 
-    project.path = pkgs.buildEnv {
+    project.packages.path = pkgs.buildEnv {
       name = "project-manager-path-for-${config.project.name}";
 
       paths = cfg.devPackages;
@@ -672,7 +659,9 @@ in {
       postBuild = cfg.extraProfileCommands;
 
       meta = {
-        description = "Environment of packages installed through Project Manager";
+        description = ''
+          Environment of packages installed through Project Manager.
+        '';
       };
     };
 
@@ -714,7 +703,7 @@ in {
       devShells = {
         default = bash-strict-mode.lib.checkedDrv pkgs (pkgs.mkShell {
           inherit (pkgs) system;
-          nativeBuildInputs = [config.project.path];
+          nativeBuildInputs = [config.project.packages.path];
           shellHook = cfg.extraProfileCommands;
           meta = {
             description = "A shell provided by Project Manager.";

--- a/nix/schemas.nix
+++ b/nix/schemas.nix
@@ -15,14 +15,15 @@ in {
           inherit forSystems;
           what = "Project Manager configuration for this flake’s project";
           children = {
-            activationPackage = {
-              inherit forSystems;
-              shortDescription = project.activationPackage.meta.description;
-              derivation = project.activationPackage;
-              evalChecks.isDerivation = checkDerivation project.activationPackage;
-              what = "package";
-              isFlakeCheck = false;
-            };
+            packages = flake-schemas.lib.mkChildren (builtins.mapAttrs (packageName: package: {
+                inherit forSystems;
+                shortDescription = package.meta.description or "";
+                derivation = package;
+                evalChecks.isDerivation = checkDerivation package;
+                what = "package";
+                isFlakeCheck = false;
+              })
+              project.packages);
             checks = flake-schemas.lib.mkChildren (builtins.mapAttrs (checkName: check: {
                 inherit forSystems;
                 shortDescription = check.meta.description or "";

--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -391,7 +391,7 @@ function doBuild() {
 
   setFlakeAttribute
   doBuildFlake \
-    "$FLAKE_CONFIG_URI.activationPackage" \
+    "$FLAKE_CONFIG_URI.packages.activation" \
     ${DRY_RUN+--dry-run} \
     ${NO_OUT_LINK+--no-link} \
     ${PRINT_BUILD_LOGS+--print-build-logs} \
@@ -413,7 +413,7 @@ function doSwitch() {
 
   setFlakeAttribute
   doBuildFlake \
-    "$FLAKE_CONFIG_URI.activationPackage" \
+    "$FLAKE_CONFIG_URI.packages.activation" \
     --out-link "$generation" \
     ${PRINT_BUILD_LOGS+--print-build-logs} \
     && "$generation/activate" || return

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@ let
   ## This follows Semantic Versioning 2.0.0 (https://semver.org/)
   version = {
     major = 0;
-    minor = 3;
+    minor = 4;
     patch = 0;
   };
 in {


### PR DESCRIPTION
This necessitates removing the old `project.packages` in favor of `project.devPackages`.