### PR TITLE
Fix a few things that got out of sync

### DIFF
--- a/.cache/vale/config/vocabularies/project-manager/accept.txt
+++ b/.cache/vale/config/vocabularies/project-manager/accept.txt
@@ -1,0 +1,17 @@
+direnv
+garnix
+[Nn]ix
+Pfeil
+ShellCheck
+babelfish
+[Bb]oolean
+declutter
+devenv
+devShell
+Dhall
+formatter
+NMT
+sandboxed
+systemd
+treefmt
+unsandboxed

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.cache/vale/Vocab/project-manager/accept.txt linguist-generated
+/.cache/vale/config/vocabularies/project-manager/accept.txt linguist-generated
 /.editorconfig linguist-generated
 /.gitattributes linguist-generated
 /.github/renovate.json linguist-generated

--- a/.vale.ini
+++ b/.vale.ini
@@ -15,4 +15,4 @@ Microsoft.Vocab=NO
 Microsoft.We=NO
 
 [*.xml]
-Transform=/nix/store/maq1x8rm00z1b1lirmj1ff2bckp349f7-docbook-xsl-ns-1.79.2/share/xml/docbook-xsl-ns/html/docbook.xsl
+Transform=/nix/store/0ji7ibzyj22dshl3b51kxzn3i9vs35d1-docbook-xsl-ns-1.79.2/share/xml/docbook-xsl-ns/html/docbook.xsl

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -288,7 +288,7 @@ in {
         onChange =
           if cfg.installConfig
           then ''
-            if $(git config --get extensions.worktreeConfig); then
+            if $(${pkgs.git}/bin/git config --get extensions.worktreeConfig); then
               scope='--worktree'
             else
               scope='--local'
@@ -298,7 +298,7 @@ in {
               include.path "${config.xdg.cacheFile."git/config".reference config.xdg.cacheFile."git/config"}"
           ''
           else ''
-            if $(git config --get extensions.worktreeConfig); then
+            if $(${pkgs.git}/bin/git config --get extensions.worktreeConfig); then
               scope='--worktree'
             else
               scope='--local'

--- a/modules/programs/vale.nix
+++ b/modules/programs/vale.nix
@@ -86,11 +86,24 @@ in {
           };
         }
         // lib.concatMapAttrs (k: v: {
+          # Need to generate files for all Vale versions in supported Nixpkgs
+          # versions until we test them in separate environments
+          # (see sellout/project-manager#69)
+          # for Vale <3.0.0
           "${actualCoreSettings.StylesPath}/Vocab/${k}/accept.txt" = lib.mkIf (v ? accept) {
             # minimum-persistence = "worktree";
             text = lib.concatLines v.accept;
           };
           "${actualCoreSettings.StylesPath}/Vocab/${k}/reject.txt" = lib.mkIf (v ? reject) {
+            # minimum-persistence = "worktree";
+            text = lib.concatLines v.reject;
+          };
+          # for Vale >=3.0.0
+          "${actualCoreSettings.StylesPath}/config/vocabularies/${k}/accept.txt" = lib.mkIf (v ? accept) {
+            # minimum-persistence = "worktree";
+            text = lib.concatLines v.accept;
+          };
+          "${actualCoreSettings.StylesPath}/config/vocabularies/${k}/reject.txt" = lib.mkIf (v ? reject) {
             # minimum-persistence = "worktree";
             text = lib.concatLines v.reject;
           };


### PR DESCRIPTION
Too many checks aren’t being run on CI, and since automated PRs don’t need to
pass the `pre-push` hook, it’s easy to miss when they don’t actually work. So,
this fixes the issues for now, and shortly there will be more complete checks
run in CI.

The included changes
- support for Vale 3.0
- correct some bare `git` calls in the activation script
- update the XML transform path