### PR TITLE
Fix unusable `init` subcommand

### DIFF
--- a/lib/bash/project-manager.bash
+++ b/lib/bash/project-manager.bash
@@ -144,11 +144,22 @@ function hasFlakeSupport() {
       | grep -q nix-command
 }
 
+function pm_setProjectRoot() {
+  ## TODO: Make the file we look for configurable, like treefmt’s
+  ##      `projectRootFile`. For now, this just finds the flake.
+  PROJECT_ROOT="$(nix flake metadata --json \
+    | jq -r ".resolvedUrl" \
+    | sed -e 's/^[^\/]*[\/]*\//\//')"
+  export PROJECT_ROOT
+}
+
 # Attempts to set the PROJECT_MANAGER_CONFIG global variable.
 #
 # If no configuration file can be found then this function will print
 # an error message and exit with an error code.
 function setConfigFile() {
+  pm_setProjectRoot
+
   if [[ -v PROJECT_MANAGER_CONFIG ]]; then
     if [[ -e $PROJECT_MANAGER_CONFIG ]]; then
       PROJECT_MANAGER_CONFIG="$(realpath "$PROJECT_MANAGER_CONFIG")"
@@ -179,6 +190,8 @@ function setConfigFile() {
 
 # Sets some useful Project Manager related paths as global read-only variables.
 function setProjectManagerPathVariables() {
+  pm_setProjectRoot
+
   # If called twice then just exit early.
   if [[ -v PM_DATA_HOME ]]; then
     return
@@ -199,103 +212,6 @@ function setFlakeAttribute() {
   local name
   name="$(nix eval --expr 'builtins.currentSystem' --impure --raw)"
   export FLAKE_CONFIG_URI="$flake#projectConfigurations.$name"
-}
-
-function pm_init() {
-  # The directory where we should place the initial configuration.
-  local confDir
-
-  # Whether we should immediate activate the configuration.
-  local switch
-
-  # Whether we should create a flake file.
-  local withFlake
-
-  if hasFlakeSupport; then
-    withFlake=1
-  fi
-
-  while (($# > 0)); do
-    local opt="$1"
-    shift
-
-    case $opt in
-      --no-flake)
-        unset withFlake
-        ;;
-      --switch)
-        switch=1
-        ;;
-      -*)
-        _iError "%s: unknown option '%s'" "$0" "$opt" >&2
-        exit 1
-        ;;
-      *)
-        if [[ -v confDir ]]; then
-          _i "Run '%s --help' for usage help" "$0" >&2
-          exit 1
-        else
-          confDir="$opt"
-        fi
-        ;;
-    esac
-  done
-
-  if [[ ! -v confDir ]]; then
-    confDir="${PROJECT_ROOT}/.config/project"
-  fi
-
-  if [[ ! -e $confDir ]]; then
-    mkdir -p "$confDir"
-  fi
-
-  if [[ ! -d $confDir ]]; then
-    _iError "%s: unknown option '%s'" "$0" "$opt" >&2
-    exit 1
-  fi
-
-  local confFile="$confDir/default.nix"
-  local flakeFile="${PROJECT_ROOT}/flake.nix"
-
-  if [[ -e $confFile ]]; then
-    _i 'The file %s already exists, leaving it unchanged...' "$confFile"
-  else
-    _i 'Creating %s...' "$confFile"
-
-    mkdir -p "$confDir"
-    cp '@CONFIG_TEMPLATE@' "$confFile"
-  fi
-
-  if [[ ! -v withFlake ]]; then
-    PROJECT_MANAGER_CONFIG="$confFile"
-  else
-    if [[ -e $flakeFile ]]; then
-      _i 'The file %s already exists, leaving it unchanged...' "$flakeFile"
-    else
-      _i 'Creating %s...' "$flakeFile"
-
-      mkdir -p "$confDir"
-      cp "@FLAKE_TEMPLATE@" "$flakeFile"
-    fi
-  fi
-
-  if [[ -v switch ]]; then
-    echo
-    _i "Creating initial Project Manager generation..."
-    echo
-
-    if pm_switch; then
-      # translators: The "%s" specifier will be replaced by a file path.
-      _i $'All done! The project-manager tool should now be installed and you can edit\n\n    %s\n\nto configure Project Manager. Run \'man project-configuration.nix\' to\nsee all available options.' \
-        "$confFile"
-      exit 0
-    else
-      # translators: The "%s" specifier will be replaced by a URL.
-      _i $'Uh oh, the installation failed! Please create an issue at\n\n    %s\n\nif the error seems to be the fault of Project Manager.' \
-        "https://github.com/nix-community/project-manager/issues"
-      exit 1
-    fi
-  fi
 }
 
 function pm_buildFlake() {
@@ -384,6 +300,7 @@ function pm_build() {
 }
 
 function pm_switch() {
+  pm_setProjectRoot
   setFlakeAttribute
   nix run \
     "$FLAKE_CONFIG_URI.packages.activation" \

--- a/modules/programs/project-manager.nix
+++ b/modules/programs/project-manager.nix
@@ -57,7 +57,6 @@ in {
     project.activation.automaticallyExpireGenerations =
       mkIf (cfg.automaticallyExpireGenerations != null)
       (pm.dag.entryAfter ["linkGeneration"] ''
-
         pm_expireGenerations ${lib.escapeShellArg cfg.automaticallyExpireGenerations}
       '');
   };

--- a/modules/project-environment.nix
+++ b/modules/project-environment.nix
@@ -714,8 +714,11 @@ in {
           git config user.name Nix
           git add .
           git commit --message "current files"
+          echo $PATH
           ## Update everything
           project-manager switch --verbose
+          echo "!!!finished switch!!!"
+          echo $PATH
           ## Make sure there are no changes
           git --no-pager diff --exit-code
         '';

--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -53,9 +53,9 @@ function showHelp() {
   echo "  build        Build configuration into result directory"
   echo
   echo "  init [--switch] [DIR]"
-  echo "      Initializes a configuration in the given directory. If the directory"
-  echo "      does not exist, then it will be created. The default directory is"
-  echo "      '~/.config/project-manager'."
+  echo "      Initializes a configuration for a project in the given directory."
+  echo "      If the directory does not exist, then it will be created. The"
+  echo "      default directory is the directory the command is run from."
   echo
   echo "      --switch      Immediately activate the generated configuration."
   echo
@@ -169,12 +169,103 @@ if [[ -z $COMMAND ]]; then
   exit 1
 fi
 
-## TODO: Make the file we look for configurable, like treefmt’s
-##      `projectRootFile`. For now, this just finds the flake.
-PROJECT_ROOT="$(nix flake metadata --json \
-  | jq -r ".resolvedUrl" \
-  | sed -e 's/^[^\/]*[\/]*\//\//')"
-export PROJECT_ROOT
+function pm_init() {
+  # The directory where we should place the initial configuration.
+  local projectDir
+
+  # Whether we should immediate activate the configuration.
+  local switch
+
+  # Whether we should create a flake file.
+  local withFlake
+
+  if hasFlakeSupport; then
+    withFlake=1
+  fi
+
+  while (($# > 0)); do
+    local opt="$1"
+    shift
+
+    case $opt in
+      --no-flake)
+        unset withFlake
+        ;;
+      --switch)
+        switch=1
+        ;;
+      -*)
+        _iError "%s: unknown option '%s'" "$0" "$opt" >&2
+        exit 1
+        ;;
+      *)
+        if [[ -v projectDir ]]; then
+          _i "Run '%s --help' for usage help" "$0" >&2
+          exit 1
+        else
+          projectDir="$opt"
+        fi
+        ;;
+    esac
+  done
+
+  PROJECT_ROOT="${projectDir:=$(pwd)}"
+  export PROJECT_ROOT
+
+  local confDir="${PROJECT_ROOT}/.config/project"
+
+  if [[ ! -e $confDir ]]; then
+    mkdir -p "$confDir"
+  fi
+
+  if [[ ! -d $confDir ]]; then
+    _iError "%s: unknown option '%s'" "$0" "$opt" >&2
+    exit 1
+  fi
+
+  local confFile="$confDir/default.nix"
+  local flakeFile="${PROJECT_ROOT}/flake.nix"
+
+  if [[ -e $confFile ]]; then
+    _i 'The file %s already exists, leaving it unchanged...' "$confFile"
+  else
+    _i 'Creating %s...' "$confFile"
+
+    mkdir -p "$confDir"
+    cp '@CONFIG_TEMPLATE@' "$confFile"
+  fi
+
+  if [[ ! -v withFlake ]]; then
+    PROJECT_MANAGER_CONFIG="$confFile"
+  else
+    if [[ -e $flakeFile ]]; then
+      _i 'The file %s already exists, leaving it unchanged...' "$flakeFile"
+    else
+      _i 'Creating %s...' "$flakeFile"
+
+      mkdir -p "$confDir"
+      cp "@FLAKE_TEMPLATE@" "$flakeFile"
+    fi
+  fi
+
+  if [[ -v switch ]]; then
+    echo
+    _i "Creating initial Project Manager generation..."
+    echo
+
+    if pm_switch; then
+      # translators: The "%s" specifier will be replaced by a file path.
+      _i $'All done! The project-manager tool should now be installed and you can edit\n\n    %s\n\nto configure Project Manager. Run \'man project-configuration.nix\' to\nsee all available options.' \
+        "$confFile"
+      exit 0
+    else
+      # translators: The "%s" specifier will be replaced by a URL.
+      _i $'Uh oh, the installation failed! Please create an issue at\n\n    %s\n\nif the error seems to be the fault of Project Manager.' \
+        "https://github.com/sellout/project-manager/issues"
+      exit 1
+    fi
+  fi
+}
 
 case $COMMAND in
   edit)

--- a/templates/default/.config/project/default.nix
+++ b/templates/default/.config/project/default.nix
@@ -15,8 +15,8 @@
     ##    `authors = [lib.maintainers.sellout];`.
     authors = ["{{project.author}}"];
     license = "{{project.license}}";
-    ## The project.packages option allows you to install Nix packages into your
-    ## environment.
+    ## The project.devPackages option allows you to install Nix packages into
+    ## your environment.
     devPackages = [
       # # Adds the 'hello' command to your environment. It prints a friendly
       # # "Hello, world!" when run.


### PR DESCRIPTION
`project-manager` calls `nix flake metadata` to set `PROJECT_ROOT`. This had been done before dispatching to a subcommand, and if `init` is used in a directory without a flake, it will fail when it tries to set `PROJECT_ROOT`.

This now moves `PROJECT_ROOT` setting to a function and only does it for subcommands that need it.

There are a couple other issues with `init` that followed this fix. E.g., the `CONFIG_TEMPLATE` and `FLAKE_TEMPLATE` vars weren’t being substituted correctly.

There is still an outstanding issue with `init --switch` failing.