### PR TITLE
Add `fmt` subcommand

### DIFF
--- a/docs/project-manager.1
+++ b/docs/project-manager.1
@@ -26,6 +26,7 @@
 .Cm | news
 .Cm | option Ar option.name
 .Cm | packages
+.Cm | fmt \&...
 .Cm | remove-generations Ar ID \&...
 .Cm | uninstall
 .Brc
@@ -142,6 +143,13 @@ Inspect the given option name in the project configuration, like
 .It Cm packages
 .RS 4
 List all packages installed in project-manager-path.
+.RE
+.Pp
+
+.It Cm fmt
+.RS 4
+Run the configured formatter. This is usually much faster than running
+\fBnix fmt\fR because it avoids evaluating the flake.
 .RE
 .Pp
 

--- a/lib/bash/project-manager.bash
+++ b/lib/bash/project-manager.bash
@@ -464,6 +464,18 @@ function pm_listPackages() {
   fi
 }
 
+function pm_format() {
+  local extraArgs=("$@")
+
+  if [[ -v __PM_FORMATTER ]]; then
+    "$__PM_FORMATTER" "${extraArgs[@]}"
+  else
+    _iWarn 'Not in a Project Manager environment. Attempting `nix fmt`, which is much slower' >&2
+    setFlakeAttribute
+    nix fmt "${extraArgs[@]}"
+  fi
+}
+
 function newsReadIdsFile() {
   local dataDir="${XDG_DATA_HOME:-$HOME/.local/share}/project-manager"
   local path="$dataDir/news-read-ids"

--- a/project-manager/completion.bash
+++ b/project-manager/completion.bash
@@ -64,6 +64,7 @@
 # news
 # option
 # packages
+# fmt
 # remove-generations
 # switch
 # uninstall
@@ -94,6 +95,7 @@
 #   remove-generations
 #   expire-generations
 #   packages
+#   fmt
 #   news
 #   uninstall
 
@@ -147,6 +149,10 @@
 #       example "-30 days" or "2018-01-01".
 #
 #   packages     List all packages installed in project-manager-path
+#
+#   fmt
+#       Run the configured formatter. This is usually much faster than running"
+#       ‘nix fmt’ because it avoids evaluating the flake."
 #
 #   news         Show news entries in a pager
 #
@@ -263,7 +269,7 @@ _project-manager_xdg-get-cache-home() {
 
 ##################################################
 
-_hm_subcommands=("help" "edit" "build" "init" "switch" "generations" "remove-generations" "expire-generations" "packages" "news" "uninstall")
+_hm_subcommands=("help" "edit" "build" "init" "switch" "generations" "remove-generations" "expire-generations" "packages" "fmt" "news" "uninstall")
 declare -ra _hm_subcommands
 
 # Finds the active sub-command, if any.
@@ -365,4 +371,4 @@ _project-manager_completions() {
 
 complete -F _project-manager_completions -o default project-manager
 
-#complete -W "help edit option build switch generations remove-generations expire-generations packages news" project-manager
+#complete -W "help edit option build switch generations remove-generations expire-generations packages fmt news" project-manager

--- a/project-manager/completion.fish
+++ b/project-manager/completion.fish
@@ -29,6 +29,7 @@ complete -c project-manager -n "__fish_use_subcommand" -f -a "build" -d "Build c
 complete -c project-manager -n "__fish_use_subcommand" -f -a "switch" -d "Build and activate configuration"
 complete -c project-manager -n "__fish_use_subcommand" -f -a "generations" -d "List all project environment generations"
 complete -c project-manager -n "__fish_use_subcommand" -f -a "packages" -d "List all packages installed in project-manager-path"
+complete -c project-manager -n "__fish_use_subcommand" -f -a "fmt" -d "Run the configured formatter. This is usually much faster than running ‘nix fmt’ because it avoids evaluating the flake."
 complete -c project-manager -n "__fish_use_subcommand" -f -a "news" -d "Show news entries in a pager"
 complete -c project-manager -n "__fish_use_subcommand" -f -a "uninstall" -d "Remove Project Manager"
 

--- a/project-manager/completion.zsh
+++ b/project-manager/completion.zsh
@@ -39,6 +39,7 @@ case "$state" in
       'remove-generations[remove generations]' \
       'expire-generations[expire generations]' \
       'packages[managed packages]' \
+      'fmt[format]' \
       'news[read the news]' \
       'uninstall[uninstall]' && ret=0
     ;;

--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -74,6 +74,10 @@ function showHelp() {
   echo
   echo "  packages     List all packages installed in project-manager-path"
   echo
+  echo "  fmt"
+  echo "      Run the configured formatter. This is usually much faster than running"
+  echo "     ‘nix fmt’ because it avoids evaluating the flake."
+  echo
   echo "  news         Show news entries in a pager"
   echo
   echo "  uninstall    Remove Project Manager"
@@ -88,7 +92,7 @@ while [[ $# -gt 0 ]]; do
   opt="$1"
   shift
   case $opt in
-    build | init | edit | expire-generations | generations | help | news | packages | remove-generations | switch | uninstall)
+    build | init | edit | expire-generations | generations | fmt | help | news | packages | remove-generations | switch | uninstall)
       COMMAND="$opt"
       ;;
     -I)
@@ -151,7 +155,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       case $COMMAND in
-        init | expire-generations | remove-generations | option)
+        init | expire-generations | remove-generations | fmt | option)
           COMMAND_ARGS+=("$opt")
           ;;
         *)
@@ -205,6 +209,9 @@ case $COMMAND in
     ;;
   packages)
     pm_listPackages
+    ;;
+  fmt)
+    pm_format "${COMMAND_ARGS[@]}"
     ;;
   news)
     pm_showNews --all


### PR DESCRIPTION
`project-manager fmt` knows the path of the configured formatter, so it can run it without evaluating the flake, unlike `nix fmt`, so it’s significantly faster.