### PR TITLE
Make determination of `PROJECT_ROOT` more robust

### DIFF
--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -175,9 +175,19 @@ fi
 
 ## TODO: Make the file we look for configurable, like treefmt’s
 ##      `projectRootFile`. For now, this just finds the flake.
+set +e
+sus_trap="$(trap -p)"
+trap -- - ERR
 PROJECT_ROOT="$(nix flake metadata --json \
   | jq -r ".resolvedUrl" \
   | sed -e 's/^[^\/]*[\/]*\//\//')"
+if [[ $? ]]; then
+  echo "WARN: Project Manager failed to find the project root via Nix, assuming"
+  echo "      it’s the current directory."
+  PROJECT_ROOT="${PWD}"
+fi
+"$sus_trap"
+set -e
 export PROJECT_ROOT
 
 case $COMMAND in


### PR DESCRIPTION
If `nix flake metadata` fails (as it seems to do in various situations), fall
back to the current directory as the project root.