### PR TITLE
Add modules to manipulate Cabal files

### DIFF
--- a/docs/manual/writing-modules/types.md
+++ b/docs/manual/writing-modules/types.md
@@ -71,21 +71,21 @@ or the order of activation script blocks in
 
         would place `b` before `a` in the graph.
 
-    []{#sec-option-types-dag-entryBetween}`hm.dag.entryBetween (befores: list string) (afters: list string) (value: T) : DagEntry<T>`
+    []{#sec-option-types-dag-entryBetween}`hm.dag.entryBetween (afters: list string) (befores: list string) (value: T) : DagEntry<T>`
 
-    :   Indicates that `value` must be placed *before* the attribute
-        names in the first list and *after* the attribute names in the
+    :   Indicates that `value` must be placed *after* the attribute
+        names in the first list and *before* the attribute names in the
         second list. For example
 
         ``` nix
         foo.bar = {
           a = 0;
-          c = hm.dag.entryBetween [ "b" ] [ "a" ] 2;
+          c = hm.dag.entryBetween [ "a" ] [ "b" ] 2;
           b = 1;
         }
         ```
 
-        would place `c` before `b` and after `a` in the graph.
+        would place `c` after `a` and before `b` in the graph.
 
     There are also a set of functions that generate a DAG from a list.
     These are convenient when you just want to have a linear list of DAG
@@ -151,11 +151,11 @@ or the order of activation script blocks in
         foo.bar = {
           b = 0;
           a-0 = 1;
-          a-1 = hm.dag.entryBetween [ "b" ] [ "a-0" ] 2;
+          a-1 = hm.dag.entryBetween [ "a-0" ] [ "b" ] 2;
         }
         ```
 
-    []{#sec-option-types-dag-entriesBetween}`hm.dag.entriesBetween (tag: string) (befores: list string) (afters: list string) (values: [T]) : Dag<T>`
+    []{#sec-option-types-dag-entriesBetween}`hm.dag.entriesBetween (tag: string) (afters: list string) (befores: list string) (values: [T]) : Dag<T>`
 
     :   Creates a DAG with the given values with each entry labeled
         using the given tag. The list of values are placed *before* each
@@ -164,18 +164,18 @@ or the order of activation script blocks in
 
         ``` nix
         foo.bar =
-          { b = 0; c = 3; }
-          // hm.dag.entriesBetween "a" [ "b" ] [ "c" ] [ 1 2 ];
+          { a = 0; c = 3; }
+          // hm.dag.entriesBetween "b" [ "a" ] [ "c" ] [ 1 2 ];
         ```
 
         is equivalent to
 
         ``` nix
         foo.bar = {
-          b = 0;
+          a = 0;
           c = 3;
-          a-0 = hm.dag.entryAfter [ "c" ] 1;
-          a-1 = hm.dag.entryBetween [ "b" ] [ "a-0" ] 2;
+          b-0 = hm.dag.entryAfter [ "a" ] 1;
+          b-1 = hm.dag.entryBetween [ "b-0" ] [ "c" ] 2;
         }
         ```
 

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -94,13 +94,13 @@ in {
   # Applies a function to each element of the given DAG.
   map = f: mapAttrs (n: v: v // {data = f n v.data;});
 
-  entryBetween = before: after: data: {inherit data before after;};
+  entryBetween = after: before: data: {inherit after before data;};
 
   # Create a DAG entry with no particular dependency information.
   entryAnywhere = pm.dag.entryBetween [] [];
 
-  entryAfter = pm.dag.entryBetween [];
-  entryBefore = before: pm.dag.entryBetween before [];
+  entryAfter = after: pm.dag.entryBetween after [];
+  entryBefore = pm.dag.entryBetween [];
 
   # Given a list of entries, this function places them in order within the DAG.
   # Each entry is labeled "${tag}-${entry index}" and other DAG entries can be
@@ -109,7 +109,7 @@ in {
   # The entries as a whole can be given a relation to other DAG nodes. All
   # generated nodes are then placed before or after those dependencies.
   entriesBetween = tag: let
-    go = i: before: after: entries: let
+    go = i: after: before: entries: let
       name = "${tag}-${toString i}";
       i' = i + 1;
     in
@@ -117,17 +117,17 @@ in {
       then pm.dag.empty
       else if length entries == 1
       then {
-        "${name}" = pm.dag.entryBetween before after (head entries);
+        "${name}" = pm.dag.entryBetween after before (head entries);
       }
       else
         {
           "${name}" = pm.dag.entryAfter after (head entries);
         }
-        // go (i + 1) before [name] (tail entries);
+        // go (i + 1) [name] before (tail entries);
   in
     go 0;
 
   entriesAnywhere = tag: pm.dag.entriesBetween tag [] [];
-  entriesAfter = tag: pm.dag.entriesBetween tag [];
-  entriesBefore = tag: before: pm.dag.entriesBetween tag before [];
+  entriesAfter = tag: after: pm.dag.entriesBetween tag after [];
+  entriesBefore = tag: pm.dag.entriesBetween tag [];
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -9,6 +9,7 @@
   # ./misc/vte.nix
   xdg = ./misc/xdg.nix;
   # ./programs/bash.nix
+  cabal2nix = ./programs/cabal2nix.nix;
   # ./programs/darcs.nix
   direnv = ./programs/direnv.nix;
   # ./programs/emacs.nix
@@ -18,6 +19,8 @@
   # ./programs/git-cliff.nix
   # ./programs/git-credential-oauth.nix
   git = ./programs/git.nix;
+  hpack = ./programs/hpack.nix;
+  hpack-dhall = ./programs/hpack-dhall.nix;
   just = ./programs/just.nix;
   mercurial = ./programs/mercurial.nix;
   # ./programs/neovim.nix

--- a/modules/programs/cabal2nix.nix
+++ b/modules/programs/cabal2nix.nix
@@ -1,0 +1,216 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.cabal2nix;
+
+  ## TODO: Implement the remaining command-line options:
+  ##     • [--hackage-db PATH]
+  ##     • [--system ARG]
+  ##     • [--hackage-snapshot ARG]
+  ##
+  ## NB: This intentionally doesn’t support the [--sha256 HASH]
+  ##     [--hpack | --no-hpack] [--revision ARG] [--subpath PATH]
+  ##     [--dont-fetch-submodules] options, per NixOS/cabal2nix#628.
+  packageModule.options = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to process this package with cabal2nix.
+      '';
+    };
+
+    benchmark = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to run benchmarks when building the package.
+      '';
+    };
+
+    check = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to run test suites when building the package.
+      '';
+    };
+
+    compiler = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "ghc-9.10.1";
+      description = ''
+        The compiler version to assume when evaluating conditionals in the Cabal
+        file. This can affect things like the set of Haskell packages available
+        to the derivation. If you have, say, conditionalized dependencies, you
+        want to choose a compiler that will include them all.
+      '';
+    };
+
+    extraArguments = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        Extra arguments to pass to the resulting derivation.
+      '';
+    };
+
+    flags = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["omit-interface-pragmas"];
+      description = ''
+        Flags to pass to the compiler when building the package. Each one will
+        be prefixed with “-f”.
+      '';
+    };
+
+    haddock = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to generate Haddock documentation as part of the derivation.
+      '';
+    };
+
+    hyperlinkSource = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to include hyperlinked source code in the derivation.
+      '';
+    };
+
+    jailbreak = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to ignore version bounds when building the package.
+      '';
+    };
+
+    maintainers = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["sellout"];
+      description = ''
+        The maintainers to include in the derivation. Each one should be a
+        string that forms a valid attribute path when appended to
+        “lib.maintainers.”.
+      '';
+    };
+
+    profiling = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum ["executable" "library"]);
+      default = [];
+      example = ["executable" "library"];
+      description = ''
+        Which components to build with profiling information.
+      '';
+    };
+
+    shell = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to generate a shell.nix-style file rather than one expected to
+        be passed to `callPackage`.
+      '';
+    };
+
+    source = lib.mkOption {
+      type = lib.types.str;
+      example = "my-package/my-package.cabal";
+      description = ''
+        The Cabal file (relative to the project root) to generate a
+        corresponding Nix file for.
+      '';
+    };
+
+    target = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "my-package/package.nix";
+      description = ''
+        The name of the Nix file to generate (relative to the project root).
+        If `null` this will use the containing attribute name with
+        “/package.nix” appended.
+      '';
+    };
+  };
+in {
+  options.programs.cabal2nix = {
+    enable =
+      lib.mkEnableOption
+      "[cabal2nix](https://github.com/nixos/cabal2nix#readme)";
+
+    package = lib.mkPackageOption pkgs "cabal2nix" {};
+
+    cabalPackage = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule packageModule);
+      default = {};
+      example = {
+        "my-project/package.nix" = {
+          benchmark = true;
+          maintainers = ["sellout"];
+          source = "my-project/my-project.cabal";
+        };
+      };
+      description = ''
+        An attribute set of the packages to process with cabal2nix.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    project.devPackages = [cfg.package];
+
+    ## TODO: Rather than generating a file directly into the tree, generate to
+    ##       the Nix store and symlink or copy via `project.file`.
+    project.activation.cabal2nix =
+      ## This ensures that Cabal files produced by hpack* will be in place when
+      ## cabal2nix wants to generate its Nix files.
+      lib.pm.dag.entryAfter ["writeBoundary" "hpack-dhall" "hpack"] (
+        lib.concatLines (
+          lib.mapAttrsToList (name: args:
+            if args.enable
+            then let
+              options =
+                lib.optional args.benchmark "--benchmark"
+                ++ lib.optional (!args.check) "--no-check"
+                ++ lib.optionals (args.compiler != null) ["--compiler" (lib.escapeShellArg args.compiler)]
+                ++ lib.concatMap (argument: ["--extra-arguments" (lib.escapeShellArg argument)]) args.extraArguments
+                ++ lib.concatMap (flag: ["--flag" (lib.escapeShellArg flag)]) args.flags
+                ++ lib.optional (!args.haddock) "--no-haddock"
+                ++ lib.optional (!args.hyperlinkSource) "--no-hyperlink-source"
+                ++ lib.optional args.jailbreak "--jailbreak"
+                ++ lib.concatMap (maintainer: ["--maintainer" (lib.escapeShellArg maintainer)]) args.maintainers
+                ++ map (type: "--enable-${type}-profiling") args.profiling
+                ++ lib.optional args.shell "--shell";
+            in ''
+              ${cfg.package}/bin/cabal2nix \
+                ${lib.concatStringsSep " " options} \
+                "$PROJECT_ROOT/${args.source}" \
+                >${lib.escapeShellArg (
+                if args.target == null
+                then "${name}/package.nix"
+                else args.target
+              )}
+            ''
+            else "")
+          cfg.cabalPackage
+        )
+      );
+  };
+}

--- a/modules/programs/hpack-dhall.nix
+++ b/modules/programs/hpack-dhall.nix
@@ -1,0 +1,92 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.hpack-dhall;
+
+  packageModule.options = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to process this package with hpack-dhall.
+      '';
+    };
+
+    outputFormat = lib.mkOption {
+      type = lib.types.enum ["cabal" "dhall" "json" "yaml"];
+      default = "cabal";
+      description = ''
+        The output format to generate from Dhall. While the default is generally
+        the right thing, if you primarily build with
+        [cabal2nix](https://github.com/nixos/cabal2nix#readme) or
+        [Stack](https://docs.haskellstack.org/) you might prefer `"yaml"`,
+        which produces [hpack](https://github.com/cabalism/hpack#readme)
+        package.yaml files that Stack can handle directly.
+      '';
+    };
+
+    source = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "my-package/package.dhall";
+      description = ''
+        The Dhall file (relative to the project root) to generate a
+        corresponding file in `outputFormat` for. If `null` this will use the
+        containing attribute name with “/package.dhall” appended.
+      '';
+    };
+  };
+in {
+  options.programs.hpack-dhall = {
+    enable =
+      lib.mkEnableOption
+      "[hpack-dhall](https://github.com/cabalism/hpack-dhall#readme)";
+
+    package = lib.mkPackageOption pkgs "hpack-dhall" {
+      default = ["haskellPackages" "hpack-dhall"];
+    };
+
+    dhallPackage = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule packageModule);
+      default = {};
+      description = ''
+        An attribute set of the packages to process with hpack-dhall.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    project.devPackages = [cfg.package];
+
+    ## TODO: Rather than generating a file directly into the tree, generate to
+    ##       the Nix store and symlink or copy via `project.file`.
+    project.activation.hpack-dhall =
+      ## This ensures that Cabal files produced by hpack-dhall will be in place
+      ## when cabal2nix or hpack want to further process them.
+      lib.pm.dag.entryBetween ["writeBoundary"] ["hpack" "cabal2nix"] (
+        lib.concatLines (lib.mapAttrsToList (name: args:
+          if args.enable
+          then let
+            src =
+              if args.source != null
+              then args.source
+              else "${name}/package.dhall";
+            ## The commands other than `dhall-hpack-cabal` output to stdout, so we
+            ## need to redirect those.
+            redirect =
+              if args.outputFormat == "cabal"
+              then ""
+              else ">$PROJECT_ROOT/${builtins.replaceStrings [".dhall"] [".${args.outputFormat}"] src}";
+          in ''
+            ${cfg.package}/bin/dhall-hpack-${args.outputFormat} \
+              --package-dhall "$PROJECT_ROOT/${src}" ${redirect}
+          ''
+          else "")
+        cfg.dhallPackage)
+      );
+  };
+}

--- a/modules/programs/hpack.nix
+++ b/modules/programs/hpack.nix
@@ -1,0 +1,123 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.hpack;
+
+  packageModule.options = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to process this package with hpack.
+      '';
+    };
+
+    canonical = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        By default, hpack takes into account aspects of the format of an
+        existing Cabal file when generating a new Cabal file. Pass this flag to
+        cause hpack to ignore the format of an existing Cabal file when
+        generating a new one.
+      '';
+    };
+
+    force = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        By default, hpack will not generate a Cabal file unnecessarily. Set this
+        to `true` to force the generation of a new Cabal file.
+      '';
+    };
+
+    hash = lib.mkOption {
+      type = lib.types.nullOr lib.types.bool;
+      default = null;
+      example = true;
+      description = ''
+        Enable/disable the inclusion of a SHA-256 hash of the other content of
+        the generated Cabal file in the header comment added by hpack to the
+        generated Cabal file.
+      '';
+    };
+
+    silent = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Output no information other than error messages.
+      '';
+    };
+
+    source = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "my-package/package.yaml";
+      description = ''
+        The YAML file (relative to the project root) to generate a
+        corresponding Cabal file for. If `null` this will use the containing
+        attribute name with “/package.yaml” appended.
+      '';
+    };
+  };
+in {
+  options.programs.hpack = {
+    enable =
+      lib.mkEnableOption
+      "[hpack](https://github.com/sol/hpack#readme)";
+
+    package = lib.mkPackageOption pkgs "hpack" {};
+
+    cabalPackage = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule packageModule);
+      default = {};
+      description = ''
+        An attribute set of the packages to process with hpack.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    project.devPackages = [cfg.package];
+
+    ## TODO: Rather than generating a file directly into the tree, generate to
+    ##       the Nix store and symlink or copy via `project.file`.
+    project.activation.hpack =
+      ## This ensures that Cabal files produced by hpack will be in place
+      ## when cabal2nix wants to further process them.
+      lib.pm.dag.entryBetween ["writeBoundary" "hpack-dhall"] ["cabal2nix"] (
+        lib.concatLines (lib.mapAttrsToList (name: args:
+          if args.enable
+          then let
+            options =
+              lib.optional args.canonical "--canonical"
+              ++ lib.optional args.force "--force"
+              ++ lib.optional (args.hash != null) (
+                if args.hash
+                then "--hash"
+                else "--no-hash"
+              )
+              ++ lib.optional args.silent "--silent";
+          in ''
+            ${cfg.package}/bin/hpack \
+              ${lib.concatStringsSep " " options} \
+              "$PROJECT_ROOT/${
+              if args.source == null
+              then "${name}/package.yaml"
+              else args.source
+            }"
+          ''
+          else "")
+        cfg.cabalPackage)
+      );
+  };
+}


### PR DESCRIPTION
This adds modules for cabal2nix, hpack, and hpack-dhall, which either generate
or process Cabal files.

Now, in a project configuration, you can write

``` nix
{
  programs = {
    hpack-dhall = {
      enable = true;
      dhallPackage.no-recursion.outputFormat = "yaml";
    };
    hpack = {
      enable = true;
      cabalPackage.no-recursion = {};
    };
    cabal2nix = {
      enable = true;
      cabalPackage.no-recursion.source = "no-recursion/no-recursion.cabal";
    };
  };
}
```

Running `project-manager switch` will then take a package.dhall file, run
`dhall-hpack-yaml` to produce a YAML  file, run `hpack`[^1] on that YAML file to
produce a Cabal file, then run `caba2nix`  on that Cabal file to produce a Nix
package file, which can then be committed to avoid IFD.

[^1]: If you remove the `outputFormat` attribute from the `hpack-dhall` section,
you can remove the `hpack` section completely – it’s only done this way to show
the complete chain.

It also corrects the argument order for `dag.entryBetween`.