### PR TITLE
Fix `PROJECT_ROOT`

### DIFF
--- a/project-manager/project-manager
+++ b/project-manager/project-manager
@@ -209,19 +209,14 @@ fi
 
 ## TODO: Make the file we look for configurable, like treefmt’s
 ##      `projectRootFile`. For now, this just finds the flake.
-set +e
-sus_trap="$(trap -p)"
-trap -- - ERR
-PROJECT_ROOT="$(nix flake metadata --json \
+if ! PROJECT_ROOT="$(nix flake metadata --json \
   | jq -r ".resolvedUrl" \
-  | sed -e 's/^[^\/]*[\/]*\//\//')"
-if [[ $? ]]; then
+  | sed -e 's/^[^\/]*[\/]*\//\//')"; then
   echo "WARN: Project Manager failed to find the project root via Nix, assuming"
   echo "      it’s the current directory."
   PROJECT_ROOT="${PWD}"
 fi
-"$sus_trap"
-set -e
+if [[ -v VERBOSE ]]; then echo "PROJECT_ROOT=$PROJECT_ROOT"; fi
 export PROJECT_ROOT
 
 case $COMMAND in


### PR DESCRIPTION
There were a few bugs around setting `PROJECT_ROOT`, such that it was effectively always the directory `project-manager` was run from, which isn’t ideal.

By looking up the root and setting the var directly in the `if` condition (as recommended by [Shellcheck](https://www.shellcheck.net/wiki/SC2181)), we avoid the fragility of suspending `trap` and disabling `-e`.

And now passing `--verbose` causes `PROJECT_ROOT` to be displayed.