### PR TITLE
Strip query parameters from `PROJECT_ROOT` URLs

### DIFF
--- a/lib/bash/project-manager.bash
+++ b/lib/bash/project-manager.bash
@@ -149,9 +149,12 @@ function pm_setProjectRoot() {
   pm_setVerboseAndDryRun
   ## TODO: Make the file we look for configurable, like treefmt’s
   ##      `projectRootFile`. For now, this just finds the flake.
+  ## NB: The `\(?.*\)\?` is to remove query parameters that are added by certain
+  ##     things, but it does mean that some valid (but unusual) paths might not
+  ##     work.
   if ! [ -v PROJECT_ROOT ] && ! PROJECT_ROOT="$(nix flake metadata --json \
     | jq -r ".resolvedUrl" \
-    | sed -e 's/^[^\/]*[\/]*\//\//')"; then
+    | sed -e 's/^[^\/]*[\/]*\(\/.*\)\(?.*\)\?/\1/')"; then
     _iWarn "Project Manager failed to find the project root via Nix, assuming it’s the current directory." >&2
     PROJECT_ROOT="${PWD}"
   fi


### PR DESCRIPTION
When discovering `PROJECT_ROOT` from the flake metadata, it may have query params (as it does when we run it in CI). This makes it not a directory path, so we need to strip that, just as we do the URL scheme.